### PR TITLE
Feature/add-prop-types

### DIFF
--- a/client/components/Todo/Todo.js
+++ b/client/components/Todo/Todo.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 
 import "./Todo.css";
 
@@ -7,5 +8,12 @@ const Todo = props => (
     <h1>{props.title}</h1>
   </article>
 );
+
+Todo.propTypes = {
+  id: PropTypes.number.isRequired,
+  title: PropTypes.string.isRequired,
+  body: PropTypes.string.isRequired,
+  completed: PropTypes.bool.isRequired
+};
 
 export default Todo;

--- a/client/containers/TodoList.js
+++ b/client/containers/TodoList.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
+import PropTypes from "prop-types";
 
 import Todo from "../components/Todo/Todo";
 import "./TodoList.css";
@@ -55,6 +56,12 @@ const mapDispatchToProps = dispatch => {
   return {
     fetchTodos: () => dispatch(actions.fetchTodos())
   };
+};
+
+TodoList.propTypes = {
+  todos: PropTypes.arrayOf(PropTypes.object.isRequired).isRequired,
+  loading: PropTypes.bool.isRequired,
+  error: PropTypes.any
 };
 
 export default connect(

--- a/client/containers/TodoList.js
+++ b/client/containers/TodoList.js
@@ -63,12 +63,10 @@ TodoList.propTypes = {
   loading: PropTypes.bool.isRequired,
 
   // This error refers to error object of state in the client/reducers/todos.js
-  error: PropTypes.objectOf(
-    PropTypes.shape({
-      message: PropTypes.string,
-      statusCode: PropTypes.number
-    })
-  )
+  error: PropTypes.shape({
+    message: PropTypes.string,
+    statusCode: PropTypes.number
+  })
 };
 
 export default connect(

--- a/client/containers/TodoList.js
+++ b/client/containers/TodoList.js
@@ -61,7 +61,14 @@ const mapDispatchToProps = dispatch => {
 TodoList.propTypes = {
   todos: PropTypes.arrayOf(PropTypes.object.isRequired).isRequired,
   loading: PropTypes.bool.isRequired,
-  error: PropTypes.any
+
+  // This error refers to error object of state in the client/reducers/todos.js
+  error: PropTypes.objectOf(
+    PropTypes.shape({
+      message: PropTypes.string,
+      statusCode: PropTypes.number
+    })
+  )
 };
 
 export default connect(

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "express": "^4.16.4",
     "html-webpack-plugin": "^3.2.0",
     "mysql2": "^1.6.4",
+    "prop-types": "^15.7.2",
     "react": "^16.8.3",
     "react-dom": "^16.8.3",
     "react-redux": "^6.0.1",


### PR DESCRIPTION
https://github.com/ha-matsumu/todo-with-express-and-mysql/pull/16#discussion_r263233933
> このファイルをみただけで、このコンポネントにはどんなpropsを受け取れるのかわかるようにしてあげたほうが良いです。(他の人が見たら、props.title しか使っていないのに、他のpropsも受け取れるの？という感じになります。)
それを解消するには prop-types を使うと解消されるかと思います。

`client/components/Todo/Todo.js`と`client/containers/TodoList.js`に`prop-types`を追加しました。レビューよろしくお願いいたします。