### PR TITLE
Feature/update-attribute-definition

### DIFF
--- a/src/migrations/20190310081931-update-attribute-definition.js
+++ b/src/migrations/20190310081931-update-attribute-definition.js
@@ -1,0 +1,17 @@
+"use strict";
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.changeColumn("Todos", "body", {
+      type: Sequelize.TEXT,
+      allowNull: true
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.changeColumn("Todos", "body", {
+      type: Sequelize.TEXT,
+      allowNull: false
+    });
+  }
+};


### PR DESCRIPTION
bodyカラムの`allowNull: false`を`allowNull: true`に変更するmigrationファイルを作成しました。
レビューよろしくお願いいたします。

`sequelize db:migrate`実行前
<img width="604" alt="before" src="https://user-images.githubusercontent.com/42855788/54082499-1205d300-435a-11e9-86f8-d2e8f52a1fc4.png">

`sequelize db:migrate`実行後
<img width="611" alt="after" src="https://user-images.githubusercontent.com/42855788/54082512-29dd5700-435a-11e9-9342-5a3aff9bbe3d.png">

